### PR TITLE
test(search): strengthen FieldRegistry coverage (closes #9)

### DIFF
--- a/test/services/search/field_registry_test.rb
+++ b/test/services/search/field_registry_test.rb
@@ -79,4 +79,65 @@ class SearchFieldRegistryTest < ActiveSupport::TestCase
     assert_includes models, 'Operator'
     assert_includes models, 'Airport'
   end
+
+  # Cross-model coverage: each SEARCHABLE_MODEL must expose its own
+  # filterable_attributes. A single expectation hash so a regression in
+  # any model's index surfaces here rather than in a downstream search test.
+  test 'fields_for covers every SEARCHABLE_MODEL with expected attributes' do
+    expectations = {
+      'Operator' => %i[id name icao_code iata_code country],
+      'AircraftType' => %i[id name type_code manufacturer category],
+      'Airport' => %i[id name city icao_code iata_code country],
+      'Country' => %i[id name iso_2char_code iso_3char_code capital],
+      'Manufacturer' => %i[id name icao_code country],
+      'Route' => %i[id call_sign operator]
+    }
+
+    expectations.each do |model_name, expected_fields|
+      actual_fields = Search::FieldRegistry.fields_for(model_name)
+
+      assert_equal expected_fields.sort, actual_fields.sort,
+                   "expected #{model_name} filterable_attributes to be #{expected_fields.inspect}"
+    end
+  end
+
+  test 'fields_for returns Symbols, not Strings' do
+    fields = Search::FieldRegistry.fields_for('Aircraft')
+
+    assert(fields.all?(Symbol), "expected all Symbols, got #{fields.map(&:class).uniq.inspect}")
+  end
+
+  # The registry swallows errors from Meilisearch's settings lookup so that
+  # an indexing misconfiguration in one model doesn't take down all field
+  # introspection (e.g., search autocomplete). Verify the rescue path by
+  # temporarily replacing `meilisearch_settings` with a raising version.
+  test 'fields_for returns empty array when the model raises' do
+    original_method = Aircraft.method(:meilisearch_settings)
+    Aircraft.define_singleton_method(:meilisearch_settings) { raise StandardError, 'boom' }
+
+    assert_equal [], Search::FieldRegistry.fields_for('Aircraft')
+  ensure
+    Aircraft.define_singleton_method(:meilisearch_settings, original_method) if original_method
+  end
+
+  test 'meilisearch_attribute_for accepts Symbol input' do
+    attr = Search::FieldRegistry.meilisearch_attribute_for('Aircraft', :registration)
+
+    assert_equal 'registration', attr
+  end
+
+  test 'suggest_fields returns results sorted by value' do
+    suggestions = Search::FieldRegistry.suggest_fields('Aircraft', 'a')
+    values = suggestions.map { |s| s[:value] }
+
+    assert_equal values.sort, values, "expected alphabetical order, got #{values.inspect}"
+  end
+
+  test 'suggest_fields produces a humanised display label' do
+    suggestions = Search::FieldRegistry.suggest_fields('Aircraft', 'aircraft_manufacturer')
+    manufacturer = suggestions.find { |s| s[:value] == 'aircraft_manufacturer' }
+
+    refute_nil manufacturer, 'expected aircraft_manufacturer in suggestions'
+    assert_equal 'Aircraft Manufacturer', manufacturer[:display]
+  end
 end


### PR DESCRIPTION
Closes #9.

## Context

Issue #9 was filed 2026-01-24 reporting "Multiple test failures for the search field registry and related services tests." Investigating today, all 53 tests in `test/services/search/` pass cleanly (verified across three consecutive runs). The original failures appear to have been resolved progressively across `e48a97b` ("fix: resolve test failures for CI"), PR #13's review rounds, and PR #15 (yesterday).

Rather than close #9 with no value delivered, this PR fills the coverage gaps that were left behind. The existing tests covered only the Aircraft model and missed several behaviours that matter for downstream consumers (autocomplete, `QueryTranslator`'s field validation, the registry's own resilience).

## Changes

`test/services/search/field_registry_test.rb` — 6 new tests, 23 new assertions, no production code touched.

| New test | What it pins down |
|---|---|
| Cross-model `fields_for` expectations | Each `SEARCHABLE_MODEL` (Operator, AircraftType, Airport, Country, Manufacturer, Route) returns its declared `filterable_attributes`. A single hash assertion so regressions surface here, not in downstream search tests. |
| `fields_for` returns Symbols | The registry's contract; `meilisearch_attribute_for` relies on `to_sym` round-trips. |
| `fields_for` rescues StandardError | The registry swallows model errors so an indexing misconfiguration in one model doesn't take down autocomplete. Verified via a singleton-method swap (Minitest 6 dropped `Object#stub`; an `ensure` block restores the original). |
| `meilisearch_attribute_for` accepts Symbol input | Matches the dual-input coverage `valid_field?` already had. |
| `suggest_fields` sort order | The method explicitly sorts by `:value`; previously only presence was checked. |
| `suggest_fields` `:display` humanisation | `humanize_field_name` calls `titleize`; was completely untested. |

## Test plan

- [x] `./bin/rails test test/services/search/field_registry_test.rb` — 18 runs, 0 failures, 44 assertions.
- [x] `./bin/rails test test/services/search/` — 59 runs, 0 failures, 133 assertions; three consecutive runs all green.
- [x] `bundle exec rubocop test/services/search/field_registry_test.rb` — no offences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)