### PR TITLE
Fix: Countries - all back to placeholder for missing flag assets

### DIFF
--- a/app/helpers/countries_helper.rb
+++ b/app/helpers/countries_helper.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
+# View helpers for rendering countries, including resolving flag assets.
 module CountriesHelper
   # The placeholder flag shown when a country has no two-character ISO code,
   # or when no matching flag asset exists on disk. Some formerly-assigned
   # ISO 3166-1 codes (e.g. "CS" for Serbia and Montenegro) have no bundled
   # flag, and Sprockets raises AssetNotFound for a missing asset, which would
   # otherwise crash the page.
-  FALLBACK_FLAG_CODE = 'xx'.freeze
+  FALLBACK_FLAG_CODE = 'xx'
 
   # Resolves the flag asset path for the given country.
   #

--- a/app/helpers/countries_helper.rb
+++ b/app/helpers/countries_helper.rb
@@ -1,0 +1,23 @@
+module CountriesHelper
+  # The placeholder flag shown when a country has no two-character ISO code,
+  # or when no matching flag asset exists on disk. Some formerly-assigned
+  # ISO 3166-1 codes (e.g. "CS" for Serbia and Montenegro) have no bundled
+  # flag, and Sprockets raises AssetNotFound for a missing asset, which would
+  # otherwise crash the page.
+  FALLBACK_FLAG_CODE = 'xx'.freeze
+
+  # Resolves the flag asset path for the given country.
+  #
+  # Falls back to the placeholder flag when the country has no two-character
+  # ISO code, or when no matching SVG exists on disk. Mirrors the on-disk
+  # lookup used by OperatorsHelper#operator_logo_for.
+  #
+  # @param country [Country] the country whose flag is required
+  # @return [String] the asset path to the flag SVG
+  def country_flag_path(country)
+    code = country&.iso_2char_code&.downcase
+    flag_file = Rails.root.join('app', 'assets', 'images', 'country_flags', "#{code}.svg")
+    code = FALLBACK_FLAG_CODE unless code.present? && File.exist?(flag_file)
+    asset_path("country_flags/#{code}.svg")
+  end
+end

--- a/app/views/countries/_country.html.erb
+++ b/app/views/countries/_country.html.erb
@@ -2,8 +2,7 @@
   <td class="whitespace-nowrap py-5 pl-4 pr-3 text-sm sm:pl-0">
     <div class="flex items-center">
       <div class="size-14 ml-1 bg-gray-200 border-2 border-purple-700 rounded-2xl overflow-hidden flex items-center">
-        <% flag_code = country.iso_2char_code&.downcase || 'xx' %>
-        <%= image_tag "country_flags/#{flag_code}.svg", class: 'h-full w-full object-cover' %>
+        <%= image_tag country_flag_path(country), class: 'h-full w-full object-cover' %>
       </div>
       <div class="ml-4">    
         <%= link_to country_path(country), class: "font-medium text-gray-900 hover:text-indigo-600" do %>

--- a/app/views/countries/show.html.erb
+++ b/app/views/countries/show.html.erb
@@ -11,8 +11,7 @@
     <div class="bg-white shadow rounded-lg">
       <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
         <div class="flex items-center">
-          <% flag_code = @country.iso_2char_code&.downcase || 'xx' %>
-          <%= image_tag "country_flags/#{flag_code}.svg", class: 'h-8 w-12 mr-3' %>
+          <%= image_tag country_flag_path(@country), class: 'h-8 w-12 mr-3' %>
           <h3 class="text-lg font-medium leading-6 text-gray-900">Country Information</h3>
         </div>
       </div>

--- a/test/controllers/countries_controller_test.rb
+++ b/test/controllers/countries_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class CountriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in @user
+  end
+
+  # Regression test for issue #18: a country with a formerly-assigned ISO code
+  # (e.g. "CS") has no bundled flag asset, which previously raised
+  # Sprockets::AssetNotFound and crashed the index.
+  test "index renders when a country has no matching flag asset" do
+    get countries_path
+
+    assert_response :success
+  end
+
+  test "show renders when the country has no matching flag asset" do
+    get country_path(countries(:serbia_and_montenegro))
+
+    assert_response :success
+  end
+end

--- a/test/controllers/countries_controller_test.rb
+++ b/test/controllers/countries_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class CountriesControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -9,15 +11,21 @@ class CountriesControllerTest < ActionDispatch::IntegrationTest
   # Regression test for issue #18: a country with a formerly-assigned ISO code
   # (e.g. "CS") has no bundled flag asset, which previously raised
   # Sprockets::AssetNotFound and crashed the index.
-  test "index renders when a country has no matching flag asset" do
+  test 'index renders the placeholder flag for a country with no matching flag asset' do
     get countries_path
 
     assert_response :success
+    # Assert the problematic row actually rendered (guards against the test
+    # becoming vacuous if the blank-query branch ever stops returning all rows)
+    # and that it fell back to the placeholder flag rather than crashing.
+    assert_select 'td', text: /Serbia and Montenegro/
+    assert_select 'img[src*=?]', "country_flags/#{CountriesHelper::FALLBACK_FLAG_CODE}"
   end
 
-  test "show renders when the country has no matching flag asset" do
+  test 'show renders the placeholder flag for a country with no matching flag asset' do
     get country_path(countries(:serbia_and_montenegro))
 
     assert_response :success
+    assert_select 'img[src*=?]', "country_flags/#{CountriesHelper::FALLBACK_FLAG_CODE}"
   end
 end

--- a/test/fixtures/countries.yml
+++ b/test/fixtures/countries.yml
@@ -36,3 +36,12 @@ australia:
   iso_num_code: 036
   name: Australia
   capital: Canberra
+
+# A formerly-assigned ISO 3166-1 code with no bundled flag asset, used to
+# exercise the missing-flag fallback (see issue #18).
+serbia_and_montenegro:
+  iso_2char_code: CS
+  iso_3char_code: SCG
+  iso_num_code: 891
+  name: Serbia and Montenegro
+  capital: Belgrade

--- a/test/helpers/countries_helper_test.rb
+++ b/test/helpers/countries_helper_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CountriesHelperTest < ActionView::TestCase
+  test 'country_flag_path returns the matching flag when the asset exists' do
+    country = countries(:united_states)
+
+    assert_equal asset_path('country_flags/us.svg'), country_flag_path(country)
+  end
+
+  test 'country_flag_path falls back to the placeholder when no flag asset exists' do
+    # "CS" is a formerly-assigned ISO code with no bundled flag (see issue #18).
+    country = countries(:serbia_and_montenegro)
+
+    assert_equal asset_path("country_flags/#{CountriesHelper::FALLBACK_FLAG_CODE}.svg"),
+                 country_flag_path(country)
+  end
+
+  test 'country_flag_path falls back to the placeholder when the code is nil' do
+    country = Country.new(iso_2char_code: nil)
+
+    assert_equal asset_path("country_flags/#{CountriesHelper::FALLBACK_FLAG_CODE}.svg"),
+                 country_flag_path(country)
+  end
+
+  test 'country_flag_path falls back to the placeholder when the country is nil' do
+    assert_equal asset_path("country_flags/#{CountriesHelper::FALLBACK_FLAG_CODE}.svg"),
+                 country_flag_path(nil)
+  end
+end


### PR DESCRIPTION
## Problem

The countries index and show pages crash when a country has an ISO 3166-1 code with no bundled flag asset. The reported case is **"CS"** (Serbia and Montenegro — a formerly-assigned code). Sprockets raises `AssetNotFound` for a missing asset, taking down the whole page.

The existing fallback in the views only handled a **nil** ISO code (`country.iso_2char_code&.downcase || 'xx'`). A code that *exists* but has no matching `*.svg` on disk slipped straight through to `image_tag`, which then raised.

Fixes #18.

## Change

- New `CountriesHelper#country_flag_path` resolves the flag, checking the asset on disk and falling back to the `xx.svg` placeholder. This mirrors the existing on-disk lookup in `OperatorsHelper#operator_logo_for`, so the approach is already established in the codebase.
- Both `_country.html.erb` and `show.html.erb` now use the helper (removing the duplicated inline logic).
- The placeholder code is a named constant (`FALLBACK_FLAG_CODE`) rather than a repeated literal.

## Tests

- `test/helpers/countries_helper_test.rb` — covers matching asset, missing-flag fallback, nil code, and nil country.
- `test/controllers/countries_controller_test.rb` — loads index and show with a new `serbia_and_montenegro` ("CS") fixture. Verified this test **fails** with the old view (`The asset "country_flags/cs.svg" is not present`) and **passes** with the fix.

All tests green; rubocop clean.